### PR TITLE
Fix JVM not exiting after closing the window

### DIFF
--- a/src/main/java/com/teamdev/jxbrowser/quickstart/gradle/swing/App.java
+++ b/src/main/java/com/teamdev/jxbrowser/quickstart/gradle/swing/App.java
@@ -29,6 +29,7 @@ import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
+import javax.swing.WindowConstants;
 
 /**
  * This example demonstrates how to initialize Chromium, create a browser instance
@@ -53,6 +54,8 @@ public final class App {
                     engine.close();
                 }
             });
+            frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+
             // Create and embed Swing BrowserView component to display web content.
             frame.add(BrowserView.newInstance(browser));
             frame.setSize(1280, 800);

--- a/src/main/kotlin/com/teamdev/jxbrowser/quickstart/gradle/swing/App.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/quickstart/gradle/swing/App.kt
@@ -26,6 +26,7 @@ import com.teamdev.jxbrowser.view.swing.BrowserView
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import javax.swing.JFrame
+import javax.swing.WindowConstants;
 import javax.swing.SwingUtilities
 
 /**
@@ -48,6 +49,8 @@ fun main() {
                     engine.close()
                 }
             })
+            defaultCloseOperation = WindowConstants.DISPOSE_ON_CLOSE
+
             // Create and embed Swing BrowserView component to display web content.
             add(BrowserView.newInstance(browser))
             setSize(1280, 800)


### PR DESCRIPTION
Fix JVM hanging after window close by correctly disposing the `JFrame`.